### PR TITLE
Set the test script to use bash instead of the default shell

### DIFF
--- a/semver_test.sh
+++ b/semver_test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 . ./semver.sh
 


### PR DESCRIPTION
I use zsh on this machine so was unable to run the tests without this change.
