### PR TITLE
Bugfix/semver lt

### DIFF
--- a/semver.sh
+++ b/semver.sh
@@ -69,12 +69,24 @@ semverLT() {
         return 0
     fi
 
-    if [[ "$MAJOR_A" -le "$MAJOR_B"  && "$MINOR_A" -lt "$MINOR_B" ]]; then
+    if [[ "$MAJOR_A" -gt "$MAJOR_B" ]]; then
+        return 1
+    fi
+
+    if [[ "$MINOR_A" -lt "$MINOR_B" ]]; then
         return 0
     fi
+
+    if [[ "$MINOR_A" -gt "$MINOR_B" ]]; then
+        return 1
+    fi
     
-    if [[ "$MAJOR_A" -le "$MAJOR_B"  && "$MINOR_A" -le "$MINOR_B" && "$PATCH_A" -lt "$PATCH_B" ]]; then
+    if [[ "$PATCH_A" -lt "$PATCH_B" ]]; then
         return 0
+    fi
+
+    if [[ "$PATCH_A" -gt "$PATCH_B" ]]; then
+        return 1
     fi
 
     if [[ "_$SPECIAL_A"  == "_" ]] && [[ "_$SPECIAL_B"  == "_" ]] ; then


### PR DESCRIPTION
Use bash in shebang
Fix shellcheck errors and warning
Fix a bug in semverLT:

There was a bug in semverLT(), when both versions
have a special field, semverLT would just compare
that special field if majorA > majorB

Before fix:
./semver.sh 8.4.2-12 6.90.5-13
8.4.2-12 -> M: 8 m:4 p:2 s:-12
6.90.5-13 -> M: 6 m:90 p:5 s:-13
8.4.2-12 == 6.90.5-13 -> 1.
8.4.2-12 < 6.90.5-13 -> 0. <- Offending result!
8.4.2-12 > 6.90.5-13 -> 1. <- Side effect because GT uses LT

After fix:
./semver.sh 8.4.2-12 6.90.5-13
8.4.2-12 -> M: 8 m:4 p:2 s:-12
6.90.5-13 -> M: 6 m:90 p:5 s:-13
8.4.2-12 == 6.90.5-13 -> 1.
8.4.2-12 < 6.90.5-13 -> 1. <- Correct
8.4.2-12 > 6.90.5-13 -> 0.